### PR TITLE
Replacing Arab Union's bugged parties

### DIFF
--- a/Divergences of Darkness/Divergences of Darkness/common/countries/Arab Union.txt
+++ b/Divergences of Darkness/Divergences of Darkness/common/countries/Arab Union.txt
@@ -2,41 +2,97 @@ color = { 66  111  19 }
 graphical_culture = MiddleEasternGC
 
 party = {
-	name = "ARA_conservative"
-	start_date = 1800.1.1
+	name = "AAA_conservative_2" # Centrists
+	start_date = 1830.1.1
 	end_date = 2000.1.1
 
 	ideology = conservative
-
-	economic_policy = state_capitalism
-	trade_policy = protectionism
-	religious_policy = moralism
-	citizenship_policy = residency
-	war_policy = pro_military
-}
-
-party = {
-	name = "ARA_liberal"
-	start_date = 1820.1.1
-	end_date = 1936.1.1
-
-	ideology = liberal
 
 	economic_policy = laissez_faire
 	trade_policy = protectionism
 	religious_policy = pluralism
 	citizenship_policy = full_citizenship
-	war_policy = pacifism
+	war_policy = anti_military
 }
 
 party = {
-	name = "ARA_reactionary"
+	name = "AAA_conservative_4" # Moderates
+	start_date = 1830.1.1
+	end_date = 2000.1.1
+
+	ideology = conservative
+
+	economic_policy = interventionism
+	trade_policy = free_trade
+	religious_policy = secularized
+	citizenship_policy = limited_citizenship
+	war_policy = anti_military
+}
+
+party = {
+	name = "AAA_liberal_2" # Parliamentarists
+	start_date = 1830.1.1
+	end_date = 2000.1.1
+
+	ideology = liberal
+
+	economic_policy = laissez_faire
+	trade_policy = free_trade
+	religious_policy = moralism
+	citizenship_policy = full_citizenship
+	war_policy = anti_military
+}
+
+party = {
+	name = "AAA_liberal_5" # National Liberals
+	start_date = 1830.1.1
+	end_date = 2000.1.1
+
+	ideology = liberal
+
+	economic_policy = state_capitalism
+	trade_policy = free_trade
+	religious_policy = secularized
+	citizenship_policy = limited_citizenship
+	war_policy = jingoism
+}
+
+party = {
+	name = "AAA_socialist_2" # Leftists
+	start_date = 1848.1.1
+	end_date = 2000.1.1
+
+	ideology = socialist
+
+	economic_policy = state_capitalism
+	trade_policy = protectionism
+	religious_policy = pluralism
+	citizenship_policy = limited_citizenship
+	war_policy = anti_military
+}
+
+party = {
+	name = "AAA_socialist_4" # Social Democrats
+	start_date = 1848.1.1
+	end_date = 2000.1.1
+
+	ideology = socialist
+
+	economic_policy = interventionism
+	trade_policy = free_trade
+	religious_policy = secularized
+	citizenship_policy = limited_citizenship
+	war_policy = pro_military
+}
+
+party = {
+	name = "AAA_reactionary_1" # Traditionalists
 	start_date = 1820.1.1
 	end_date = 2000.1.1
 
 	ideology = reactionary
 
-	economic_policy = state_capitalism
+	economic_policy = agrarianism
 	trade_policy = protectionism
 	religious_policy = moralism
 	citizenship_policy = residency
@@ -44,7 +100,7 @@ party = {
 }
 
 party = {
-	name = "ARA_anarcho_liberals"
+	name = "AAA_anarcho_liberal_1" # Free Trade Party
 	start_date = 1830.1.1
 	end_date = 2000.1.1
 
@@ -52,27 +108,13 @@ party = {
 
 	economic_policy = laissez_faire
 	trade_policy = free_trade
-	religious_policy = pro_atheism
-	citizenship_policy = full_citizenship
-	war_policy = pro_military
-}
-
-party = {
-	name = "ARA_socialist"
-	start_date = 1848.1.1
-	end_date = 2000.1.1
-
-	ideology = socialist
-
-	economic_policy = planned_economy
-	trade_policy = protectionism
 	religious_policy = secularized
 	citizenship_policy = full_citizenship
-	war_policy = anti_military
+	war_policy = pacifism
 }
 
 party = {
-	name = "ARA_communist"
+	name = "AAA_communist_1" # Workers' Party
 	start_date = 1848.1.1
 	end_date = 2000.1.1
 
@@ -81,12 +123,12 @@ party = {
 	economic_policy = planned_economy
 	trade_policy = protectionism
 	religious_policy = pro_atheism
-	citizenship_policy = full_citizenship
+	citizenship_policy = residency
 	war_policy = pro_military
 }
 
 party = {
-	name = "ARA_fascist"
+	name = "AAA_fascist_2" # Falangists
 	start_date = 1905.1.1
 	end_date = 2000.1.1
 
@@ -96,7 +138,7 @@ party = {
 	trade_policy = protectionism
 	religious_policy = moralism
 	citizenship_policy = residency
-	war_policy = jingoism
+	war_policy = pro_military
 }
 
 unit_names = {


### PR DESCRIPTION
When you form the Arab Union, you receive a janky list of "Aragonese" parties due to mislabeled party names. Aragon does not themselves receive these parties, so I replaced them with one of the generic party lists.