### PR TITLE
Change Qingqiu's Manifest Destiny to improve borders

### DIFF
--- a/Divergences of Darkness/Divergences of Darkness/decisions/ManifestDestiny.txt
+++ b/Divergences of Darkness/Divergences of Darkness/decisions/ManifestDestiny.txt
@@ -230,7 +230,7 @@ political_decisions = {
 			MEX_103 = {
 				add_core = DNG
 			}
-			TEX_132 = {
+			MEX_2138 = {
 				add_core = DNG
 			}
 			NA_109 = {


### PR DESCRIPTION
Qingqiu will get cores on the state of Santa Catarina instead of Lusitania when they fire "Destiny of the West". This means there will no longer be an awkward tentacle of doom cutting into Texas if the AI ever manages to claim all its cores.