### PR TITLE
Athens university requirements fix, Missing Syrian Core added

### DIFF
--- a/Divergences of Darkness/Divergences of Darkness/common/event_modifiers.txt
+++ b/Divergences of Darkness/Divergences of Darkness/common/event_modifiers.txt
@@ -636,6 +636,75 @@ kiel_canal_construction = {
 panama_canal_construction = {
 	icon = 11
 }
+####ADDITIONAL canal modifires used in the DoD canal desicions. 
+#### Suez Canal ####
+building_suez_canal = {
+	prestige = 0.03
+	icon = 9
+}
+
+building_suez_canal_revolt = {
+	icon = 16
+}
+
+suez_canal = {
+	prestige = 0.05
+	icon = 15
+}
+
+suez_canal_dividend = {
+	icon = 9
+}
+
+suez_canal_treaty = {
+	icon = 5
+}
+
+suez_canal_treaty_annuity = {
+	icon = 9
+}
+
+
+#### Panama Canal ####
+building_panama_canal = {
+	prestige = 0.03
+	icon = 9
+}
+
+panama_canal = {
+	prestige = 0.05
+	icon = 15
+}
+
+panama_canal_dividend = {
+	icon = 9
+}
+
+panama_canal_treaty = {
+	icon = 5
+}
+
+panama_canal_treaty_annuity = {
+	icon = 9
+}
+
+building_panama_canal_scandal = {
+	icon = 10
+}
+
+#### Kiel Canal ####
+building_kiel_canal = {
+	icon = 9
+}
+
+kiel_canal = {
+	prestige = 0.03
+	icon = 15
+}
+
+kiel_canal_dividend = {
+	icon = 9
+}
 
 eiffel_tower_construction = {
 	icon = 11
@@ -1231,6 +1300,11 @@ the_homestead_act = {
 	global_immigrant_attract = 0.5	#50%
 	global_assimilation_rate = 0.5
 	core_pop_militancy_modifier = -0.05
+	icon = 9
+}
+the_homestead_act2 = {
+	global_immigrant_attract = 0.5	#50%
+	global_assimilation_rate = 0.5
 	icon = 9
 }
 

--- a/Divergences of Darkness/Divergences of Darkness/decisions/GRE.txt
+++ b/Divergences of Darkness/Divergences of Darkness/decisions/GRE.txt
@@ -190,6 +190,7 @@ political_decisions = {
 		potential = { 
 		owns = 834
 		OR = { 
+		primary_culture = venetian
 		tag = GRE 
 		tag = VEN 
 		tag = MAC
@@ -450,7 +451,7 @@ political_decisions = {
 				}
 			}
 			861 = {
-				change_province_name = "Üsküdar"
+				change_province_name = "ÃœskÃ¼dar"
 			}
 			prestige = 2
 			random_country = {

--- a/Divergences of Darkness/Divergences of Darkness/history/provinces/balkan/912 - Baalbeck.txt
+++ b/Divergences of Darkness/Divergences of Darkness/history/provinces/balkan/912 - Baalbeck.txt
@@ -2,6 +2,7 @@ owner = TUR
 controller = TUR
 add_core = TUR
 add_core = LBN
+add_core = SYR
 trade_goods = timber
 life_rating = 35
 


### PR DESCRIPTION
-I added the primary culture as venetian to the Athens University descision so that super Quick Italy doesn't stop the Decision.
(I also added it to the accept Greek culture desicions in my personal game but i don't know if you want to do that here. IE a venice formed italy can still accept greece even if you do it really fast)
-Also added the Missing Syrian Core