### PR TITLE
Correct impossible South African decision

### DIFF
--- a/Divergences of Darkness/Divergences of Darkness/decisions/SAF.txt
+++ b/Divergences of Darkness/Divergences of Darkness/decisions/SAF.txt
@@ -141,7 +141,7 @@ political_decisions = {
 	
 	Baastards_SAF = { 
 		potential = { 
-			tag = BTV 
+			tag = SAF 
 			NOT = { has_country_flag = baastards_SAF }
 			has_country_flag = claim_south_africa
 			owns = 2574


### PR DESCRIPTION
Baastards_SAF can not even be shown if you expect the tag to be BTV and have claim_south_africa